### PR TITLE
Added CommandBindings to ModalContentPresenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /ModalContentPresenter/obj
 /ModalContentPresenterTestApp/bin
 /ModalContentPresenterTestApp/obj
+*.suo

--- a/ModalContentPresenter/ModalContentPresenter.cs
+++ b/ModalContentPresenter/ModalContentPresenter.cs
@@ -24,6 +24,18 @@ using System.Windows.Media;
 namespace Benjamin.Gale.Controls
 {
     /// <summary>
+    /// Supplys commands for opening and closing the modal.
+    /// </summary>
+    public static class ModalContentPresenterCommands
+    {
+        // Command to invoke ShowModalContent()
+        public static readonly ICommand ShowModalContent = new RoutedCommand();
+
+        // Command to invoke HideModalContent()
+        public static readonly ICommand HideModalContent = new RoutedCommand();
+    }
+
+    /// <summary>
     /// Allows the display of modal content over another piece of content.
     /// </summary>
     [ContentProperty("Content")]
@@ -243,26 +255,17 @@ namespace Benjamin.Gale.Controls
 
         #endregion
 
-        #region ICommands
-
-        // Command to invoke ShowModalContent()
-        public ICommand ShowModalContentCommand { get; private set; }
-
-        // Command to invoke HideModalContent()
-        public ICommand HideModalContentCommand { get; private set; }
+        #region command bindings
 
         /// <summary>
-        /// Creates commands and adds CommandBindings
+        /// Add CommandBindings
         /// </summary>
         private void CreateCommands()
         {
-            this.ShowModalContentCommand = new RoutedCommand();
-            this.HideModalContentCommand = new RoutedCommand();
-
-            CommandBinding showModalCommandBinding = new CommandBinding(this.ShowModalContentCommand, (sender, args) => this.ShowModalContent(), (sender, args) => args.CanExecute = true);
-            CommandBinding hideModalCommandBinding = new CommandBinding(this.HideModalContentCommand, (sender, args) => this.HideModalContent(), (sender, args) => args.CanExecute = true);
-
+            CommandBinding showModalCommandBinding = new CommandBinding(ModalContentPresenterCommands.ShowModalContent, (sender, args) => this.ShowModalContent(), (sender, args) => args.CanExecute = !this.IsModal);
             this.CommandBindings.Add(showModalCommandBinding);
+
+            CommandBinding hideModalCommandBinding = new CommandBinding(ModalContentPresenterCommands.HideModalContent, (sender, args) => this.HideModalContent(), (sender, args) => args.CanExecute = this.IsModal);
             this.CommandBindings.Add(hideModalCommandBinding);
         }
 
@@ -296,7 +299,7 @@ namespace Benjamin.Gale.Controls
             layoutRoot.Children.Add(primaryContentPresenter);
             layoutRoot.Children.Add(overlay);
 
-            this.CreateCommands();
+            CreateCommands();
         }
 
         /// <summary>

--- a/ModalContentPresenter/ModalContentPresenter.cs
+++ b/ModalContentPresenter/ModalContentPresenter.cs
@@ -243,6 +243,31 @@ namespace Benjamin.Gale.Controls
 
         #endregion
 
+        #region ICommands
+
+        // Command to invoke ShowModalContent()
+        public ICommand ShowModalContentCommand { get; private set; }
+
+        // Command to invoke HideModalContent()
+        public ICommand HideModalContentCommand { get; private set; }
+
+        /// <summary>
+        /// Creates commands and adds CommandBindings
+        /// </summary>
+        private void CreateCommands()
+        {
+            this.ShowModalContentCommand = new RoutedCommand();
+            this.HideModalContentCommand = new RoutedCommand();
+
+            CommandBinding showModalCommandBinding = new CommandBinding(this.ShowModalContentCommand, (sender, args) => this.ShowModalContent(), (sender, args) => args.CanExecute = true);
+            CommandBinding hideModalCommandBinding = new CommandBinding(this.HideModalContentCommand, (sender, args) => this.HideModalContent(), (sender, args) => args.CanExecute = true);
+
+            this.CommandBindings.Add(showModalCommandBinding);
+            this.CommandBindings.Add(hideModalCommandBinding);
+        }
+
+        #endregion
+
         #region ModalContentPresenter implementation
 
         static ModalContentPresenter()
@@ -270,6 +295,8 @@ namespace Benjamin.Gale.Controls
 
             layoutRoot.Children.Add(primaryContentPresenter);
             layoutRoot.Children.Add(overlay);
+
+            this.CreateCommands();
         }
 
         /// <summary>

--- a/ModalContentPresenterTestApp/MainWindow.xaml
+++ b/ModalContentPresenterTestApp/MainWindow.xaml
@@ -33,7 +33,7 @@ limitations under the License.
             <TabItem Header="Tab two">
                 <Button Margin="55"
                         Padding="10"
-                        Command="{Binding ElementName=modalPresenter, Path=ShowModalContentCommand}">
+                        Command="{Binding Source={x:Static c:ModalContentPresenterCommands.ShowModalContent}}">
                     Show modal content by command binding
                 </Button>
             </TabItem>
@@ -49,7 +49,7 @@ limitations under the License.
                 </Button>
                 <Button Margin="10"
                         Padding="20"
-                        Command="{Binding ElementName=modalPresenter, Path=HideModalContentCommand}">
+                        Command="{Binding Source={x:Static c:ModalContentPresenterCommands.HideModalContent}}">
                     Hide modal content by command binding
                 </Button>
             </StackPanel>

--- a/ModalContentPresenterTestApp/MainWindow.xaml
+++ b/ModalContentPresenterTestApp/MainWindow.xaml
@@ -27,7 +27,14 @@ limitations under the License.
                 <Button Margin="55"
                         Padding="10"
                         Click="ShowModalContent">
-                    Show modal content
+                    Show modal content by code behind
+                </Button>
+            </TabItem>
+            <TabItem Header="Tab two">
+                <Button Margin="55"
+                        Padding="10"
+                        Command="{Binding ElementName=modalPresenter, Path=ShowModalContentCommand}">
+                    Show modal content by command binding
                 </Button>
             </TabItem>
         </TabControl>
@@ -35,10 +42,15 @@ limitations under the License.
         <c:ModalContentPresenter.ModalContent>
             <StackPanel Orientation="Vertical"
                         VerticalAlignment="Center">
-                <Button Margin="75"
-                        Padding="50"
+                <Button Margin="10"
+                        Padding="20"
                         Click="HideModalContent">
-                    Hide modal content
+                    Hide modal content by code behind
+                </Button>
+                <Button Margin="10"
+                        Padding="20"
+                        Command="{Binding ElementName=modalPresenter, Path=HideModalContentCommand}">
+                    Hide modal content by command binding
                 </Button>
             </StackPanel>
         </c:ModalContentPresenter.ModalContent>


### PR DESCRIPTION
Added CommandBindings to ModalContentPresenter to support direct binding
in XAML.
Updated TestApp to show usage.

The reason is I wanted to bind commands directly avoiding the need to create any code behind.
